### PR TITLE
Footer Now Uses Projects's Last Stable GitHub Release Publish Date

### DIFF
--- a/src/Components/FooterWrapper.jsx
+++ b/src/Components/FooterWrapper.jsx
@@ -1,12 +1,30 @@
-import React from 'react';
 import { Footer, Text } from 'grommet';
+import React, { useEffect, useState } from 'react';
 import { GitHubSvg } from './Logos/GitHubSvg';
 import { LinkedinSvg } from './Logos/LinkedinSvg';
 
-export const FooterWrapper = () => (
-  <Footer className="footer" background="#000" pad="medium">
+export const FooterWrapper = () => {
+  const [lastUpdated, setLastUpdated] = useState('');
+
+  useEffect(() => {
+    const fetchLastUpdated = async () => {
+      const response = await fetch(
+        'https://api.github.com/repos/rahul-kulkarni105/portfolio/releases/latest'
+      )
+
+      const body = await response.json()
+      const date = new Date(body.published_at)
+      const formattedDate = new Intl.DateTimeFormat('en-US').format(date)
+      setLastUpdated(formattedDate)
+    }
+
+    fetchLastUpdated()
+  }, []);
+
+  return (
+    <Footer className="footer" background="#000" pad="medium">
     <section>
-      <Text className="p-2 footer__text">Last updated: 07-12-2020</Text>
+      <Text className="p-2 footer__text">Last updated: {lastUpdated}</Text>
     </section>
     <section>
       <GitHubSvg
@@ -19,4 +37,5 @@ export const FooterWrapper = () => (
       />
     </section>
   </Footer>
-);
+  );
+};

--- a/src/Components/FooterWrapper.jsx
+++ b/src/Components/FooterWrapper.jsx
@@ -10,15 +10,15 @@ export const FooterWrapper = () => {
     const fetchLastUpdated = async () => {
       const response = await fetch(
         'https://api.github.com/repos/rahul-kulkarni105/portfolio/releases/latest'
-      )
+      );
 
-      const body = await response.json()
-      const date = new Date(body.published_at)
-      const formattedDate = new Intl.DateTimeFormat('en-US').format(date)
-      setLastUpdated(formattedDate)
+      const body = await response.json();
+      const date = new Date(body.published_at);
+      const formattedDate = new Intl.DateTimeFormat('en-US').format(date);
+      setLastUpdated(formattedDate);
     }
 
-    fetchLastUpdated()
+    fetchLastUpdated();
   }, []);
 
   return (


### PR DESCRIPTION
## Problem
I noticed the footer was making use of a hardcoded date and it was sometimes not getting updated when changes were deployed.

## Solution
The date is now populated by the projects last stable GitHub release publish date using the GitHub API.

One other minor change. The previous date format did not seem to be a "official date" format? `DateTimeFormat` did not seem to obviously support the format. So the date is now formatted using the `en-US` locale which looks like this: `11/10/2020`.


